### PR TITLE
CI: Drop unused Travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,4 @@ env:
 
 before_install: gem install bundler
 
-sudo: false
-
 cache: bundler


### PR DESCRIPTION
The Travis setting sudo: false has been removed - See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration