### PR TITLE
Fix compatibility with Minitest 5+

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ Dir["#{current_directory}/fixtures/**/*.rb"].each do |fixture|
 end
 
 module Skiptrace
-  class Test < MiniTest::Test
+  class Test < Minitest::Test
     def self.test(name, &block)
       define_method("test_#{name}", &block)
     end


### PR DESCRIPTION
The `MiniTest` was renamed to `Minitest`:

https://github.com/minitest/minitest/commit/9a57c520ceac76abfe6105866f8548a94eb357b6

And the `MiniTest` constant is now loaded just when `MT_COMPAT` environment variable is set:

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6

Without this, the test suite fails testing with Minitest 5.19+:

~~~
$ ruby -I~/build/BUILD/bindex-0.8.1/usr/lib64/gems/ruby/bindex-0.8.1:lib:test -e 'Dir.glob "./test/**/*_test.rb", &method(:require)'
/builddir/build/BUILD/bindex-0.8.1/usr/share/gems/gems/bindex-0.8.1/test/test_helper.rb:14:in `<module:Skiptrace>': uninitialized constant Skiptrace::MiniTest (NameError)
  class Test < MiniTest::Test
                       ^^^^^^
Did you mean?  Minitest
	from /builddir/build/BUILD/bindex-0.8.1/usr/share/gems/gems/bindex-0.8.1/test/test_helper.rb:13:in `<top (required)>'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /builddir/build/BUILD/bindex-0.8.1/usr/share/gems/gems/bindex-0.8.1/test/skiptrace/current_bindings_test.rb:1:in `<top (required)>'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:dir>:220:in `glob'
	from -e:1:in `<main>'
~~~